### PR TITLE
Include install_requires and replace requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ default:
 .PHONY: venv
 venv: $(VENV_ACTIVATE)
 
-$(VENV_ACTIVATE): requirements*.txt
+$(VENV_ACTIVATE): requirements*.txt setup.py
 	test -f $@ || virtualenv --python=python2.7 $(VENV_DIR)
 	$(WITH_VENV) pip install --no-deps -r requirements-setup.txt
-	$(WITH_VENV) pip install --no-deps -r requirements.txt
+	$(WITH_VENV) pip install -e .
 	$(WITH_VENV) pip install --no-deps -r requirements-dev.txt
 
 develop: venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-django-auth-ldap>=1.2.8
-funcparserlib>=0.3.6  # required by mockldap, but not declared as a dependency?
-six>=1.3

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,10 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
     ],
+    install_requires=[
+        'django-auth-ldap>=1.2.8',
+        'six>=1.3'
+    ],
     packages=find_packages(exclude=[
         'tests', 'tests.*']),
     include_package_data=True,


### PR DESCRIPTION
So it stays a well-behaved python package

1. Stop using no-deps for main install
2. move requirements.txt into install_requires